### PR TITLE
fix extern GC_jmp_buf for GCC 10

### DIFF
--- a/src/gc-7.2/include/private/gc_priv.h
+++ b/src/gc-7.2/include/private/gc_priv.h
@@ -2325,7 +2325,7 @@ GC_INNER ptr_t GC_store_debug_info(ptr_t p, word sz, const char *str,
 
 #if defined(NEED_FIND_LIMIT) \
      || (defined(USE_PROC_FOR_LIBRARIES) && defined(THREADS))
-  JMP_BUF GC_jmp_buf;
+  extern JMP_BUF GC_jmp_buf;
 
   /* Set up a handler for address faults which will longjmp to  */
   /* GC_jmp_buf;                                                */

--- a/src/gc-7.2/mark.c
+++ b/src/gc-7.2/mark.c
@@ -15,6 +15,7 @@
  */
 
 #include "private/gc_pmark.h"
+#include "private/gc_priv.h"
 
 #include <stdio.h>
 

--- a/src/gc-7.2/os_dep.c
+++ b/src/gc-7.2/os_dep.c
@@ -139,6 +139,12 @@
 
 #define READ read
 
+#if defined(NEED_FIND_LIMIT) \
+     || (defined(USE_PROC_FOR_LIBRARIES) && defined(THREADS))
+JMP_BUF GC_jmp_buf;
+#endif /* NEED_FIND_LIMIT || USE_PROC_FOR_LIBRARIES */
+
+
 /* Repeatedly perform a read call until the buffer is filled or */
 /* we encounter EOF.                                            */
 STATIC ssize_t GC_repeat_read(int fd, char *buf, size_t count)


### PR DESCRIPTION
resolves #11
msa build fails with GCC 10

error: multiple definition of 'GC_jmp_buf' 
GCC 10 defaults to -fno-common, which means a linker error will now be reported. To fix this, use extern in header files when declaring global variables, and ensure each global is defined in exactly one C file.
