### PR TITLE
Fixes #27 - Add -lpthread to PKG_LIBS for Linux

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-PKG_LIBS=`${R_HOME}/bin${R_ARCH_BIN}/Rscript -e "if (Sys.info()['sysname'] == 'Darwin') cat('-Wl,-all_load ./libgc.a ./libClustalW.a ./libClustalOmega.a ./libMuscle.a') else cat('-Wl,--whole-archive ./libgc.a ./libClustalW.a ./libClustalOmega.a ./libMuscle.a  -Wl,--no-whole-archive')"`
+PKG_LIBS=`${R_HOME}/bin${R_ARCH_BIN}/Rscript -e "if (Sys.info()['sysname'] == 'Darwin') cat('-Wl,-all_load ./libgc.a ./libClustalW.a ./libClustalOmega.a ./libMuscle.a') else cat('-Wl,--whole-archive ./libgc.a ./libClustalW.a ./libClustalOmega.a ./libMuscle.a  -Wl,--no-whole-archive -lpthread')"`
 PKG_CXXFLAGS=-I"./gc-8.2.2/include" -I"./Muscle/" -I"./ClustalW/src" -I"./ClustalOmega/src"
 
 .PHONY: all mylibs


### PR DESCRIPTION
This makes it possible to build `msa` for Bioconda (on CentOS 7) on ARM64.