### PR TITLE
fix segfault when doing profile alignment

### DIFF
--- a/R/msaClustalOmega.R
+++ b/R/msaClustalOmega.R
@@ -59,10 +59,21 @@ msaClustalOmega <- function(inputSeqs,
     #############
     # order     #
     #############
-    order <- match.arg(order)
-    params[["outputOrder"]] <- switch(order,
-                                      aligned="tree-order",
-                                      input="input-order")
+    ##https://github.com/UBod/msa/issues/35
+    ##specifying the output order and profile1 at the same time causes segfault
+    ##this is an upstream bug in Clustal Omega
+    if (!is.null(params[["profile1"]])) {
+        if (!missing(order)) {
+            warning("The parameter order cannot be set with profile1,\n",
+                "leaving output-order as default instead...\n")
+        }
+        ##simply leave params[["outputOrder"]] undefined to keep default
+    } else {
+        order <- match.arg(order)
+        params[["outputOrder"]] <- switch(order,
+                                        aligned="tree-order",
+                                        input="input-order")
+    }
 
     ###########
     # cluster #


### PR DESCRIPTION
Resolves #35.

Specifying both the --output-order and --profile1 arguments at the same time leads to a segfault. This issue is also present in the upstream Clustal Omega source code. This pull request works around the issue by not supplying --output-order when a profile is used. If no profile is supplied, then everything works just like before.